### PR TITLE
Fix #33 and remove the check that would hide a row with an empty MAC

### DIFF
--- a/supportfiles/adminportals/modules/endpoints/endpoints.inc.php
+++ b/supportfiles/adminportals/modules/endpoints/endpoints.inc.php
@@ -29,6 +29,7 @@
 	$currentPage = (isset($_GET['currentPage'])) ? $_GET['currentPage'] : 1;
 	
 	$associationList = $ipskISEDB->getEndPointAssociations();
+	$pageStart = 0;
 	$pageEnd = $associationList['count'];
 		
 	if($associationList){
@@ -48,11 +49,6 @@
 					}
 				}else{
 					$expiration = "Suspended";
-				}
-
-				// Skips adding the row to the table if the MAC address is empty.
-				if ($associationList[$idxId]['macAddress'] == "") {
-					continue;
 				}
 
 				$pageData['endpointAssociationList'] .= '<tr>';


### PR DESCRIPTION
This will fix #33 by initializing the `$pageStart` variable. It also removes the `continue` statement if the endpoint entry does not have a MAC address, which was the workaround for removing the "Suspended" entry from showing up in the table. 

The "Suspended" entry was actually caused because `$pageStart` was not initialized - not because the DB table actually contained an endpoint without a MAC.